### PR TITLE
Make it use the mirror by default, and add necessary headers

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -24,7 +24,7 @@ cat > $payload <&0
 
 insecure_registries=$(jq -r '.source.insecure_registries // [] | join(" ")' < $payload)
 
-registry_mirror=$(jq -r '.source.registry_mirror // ""' < $payload)
+registry_mirror=$(jq -r '.source.registry_mirror // "http://docker-mirror:5000"' < $payload)
 
 username=$(jq -r '.source.username // ""' < $payload)
 password=$(jq -r '.source.password // ""' < $payload)

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -38,7 +38,11 @@ func main() {
 	rECRRepo, err := regexp.Compile(`[a-zA-Z0-9][a-zA-Z0-9_-]*\.dkr\.ecr\.[a-zA-Z0-9][a-zA-Z0-9_-]*\.amazonaws\.com(\.cn)?[^ ]*`)
 	fatalIf("failed to compile ECR regex", err)
 
-	var request CheckRequest
+	request := CheckRequest{
+		Source: Source{
+			RegistryMirror: "http://docker-mirror:5000",
+		},
+	}
 	err = json.NewDecoder(os.Stdin).Decode(&request)
 	fatalIf("failed to read request", err)
 
@@ -119,6 +123,8 @@ func headDigest(client *http.Client, manifestURL, repository, tag string) (strin
 	manifestRequest, err := http.NewRequest("HEAD", manifestURL, nil)
 	fatalIf("failed to build manifest request", err)
 	manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	manifestRequest.Header.Add("Accept", "application/vnd.oci.image.manifest.v1+json")
+	manifestRequest.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 	manifestRequest.Header.Add("Accept", "application/json")
 
 	manifestResponse, err := client.Do(manifestRequest)
@@ -146,6 +152,8 @@ func fetchDigest(client *http.Client, manifestURL, repository, tag string) (stri
 	manifestRequest, err := http.NewRequest("GET", manifestURL, nil)
 	fatalIf("failed to build manifest request", err)
 	manifestRequest.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	manifestRequest.Header.Add("Accept", "application/vnd.oci.image.manifest.v1+json")
+	manifestRequest.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 	manifestRequest.Header.Add("Accept", "application/json")
 
 	manifestResponse, err := client.Do(manifestRequest)


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

This branch has image tag `mirror-1`.

See this slack thread for why the headers are needed: https://opendoor.slack.com/archives/C066PGLK77B/p1714072860609209

This also makes the mirror the default, since we plan to use it everywhere, it'll save typing in the pipelines.

## Test Plan

Tested this out on one of our pipelines and it works.

## Mitigation

<!-- Please estimate the potential impact of your change and how we can roll back or mitigate any issues that may arise. Are there feature flags or monitoring in place? -->

## Checklist

<!-- This is a checklist. To mark an item as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to external documentation if necessary (READMEs, Confluence, etc.)
- [ ] I have checked that other PRs this PR depends on have already been deployed.
- [ ] I can confirm that if this PR introduces a DB schema change, I have read and followed all the steps outlined in the [Data Contract](https://docs.google.com/document/d/1g_ZZ8TU58Dh2Fn_6aNHktBUNdnBtYNuOyu3GY-kGHnk/edit#heading=h.o2ce6n1q3gpb).

<!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->
